### PR TITLE
Fix CSV round-trip for flags

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -11,6 +11,8 @@ def load_data():
     transactions = pd.read_csv('synthetic_transactions.csv', parse_dates=['transaction_date'])
     customers = pd.read_csv('synthetic_customers.csv')
     flagged = pd.read_csv('flagged_transactions.csv', parse_dates=['transaction_date'])
+    # Convert semicolon separated flags back to a Python list
+    flagged['flags'] = flagged['flags'].fillna('').apply(lambda x: x.split(';') if x else [])
     return transactions, customers, flagged
 
 transactions, customers, flagged = load_data()

--- a/detection_scenarios.py
+++ b/detection_scenarios.py
@@ -74,7 +74,10 @@ high_risk_countries = ["Afghanistan", "Albania", "Barbados", "Burkina Faso", "Ca
 transactions = apply_high_risk_country_rule(transactions, high_risk_countries)
 
 # Extract flagged transactions
-flagged_transactions = transactions[transactions['flags'].apply(len) > 0]
+flagged_transactions = transactions[transactions['flags'].apply(len) > 0].copy()
+
+# Convert list of flags to a string so it round-trips via CSV
+flagged_transactions['flags'] = flagged_transactions['flags'].apply(lambda x: ';'.join(x))
 
 # Save flagged transactions to CSV
 flagged_transactions.to_csv('flagged_transactions.csv', index=False)


### PR DESCRIPTION
## Summary
- ensure flagged transactions save lists as semicolon separated strings
- parse `flags` column back into list when loading dashboard data

## Testing
- `python -m py_compile dashboard.py detection_scenarios.py synthetic_data.py`

------
https://chatgpt.com/codex/tasks/task_e_683f4bd0f908833292be5a35f2b5612b