### PR TITLE
Fix flag parsing and add basic tests

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -1,6 +1,7 @@
 import streamlit as st
 import pandas as pd
 import plotly.express as px
+import ast
 
 # Set page configuration
 st.set_page_config(page_title="AML Detection Dashboard", layout="wide")
@@ -11,8 +12,8 @@ def load_data():
     transactions = pd.read_csv('synthetic_transactions.csv', parse_dates=['transaction_date'])
     customers = pd.read_csv('synthetic_customers.csv')
     flagged = pd.read_csv('flagged_transactions.csv', parse_dates=['transaction_date'])
-    # Convert semicolon separated flags back to a Python list
-    flagged['flags'] = flagged['flags'].fillna('').apply(lambda x: x.split(';') if x else [])
+    # Convert string representation of lists back to actual lists
+    flagged['flags'] = flagged['flags'].fillna('[]').apply(ast.literal_eval)
     return transactions, customers, flagged
 
 transactions, customers, flagged = load_data()

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -1,0 +1,40 @@
+import pandas as pd
+from pathlib import Path
+import os
+from dashboard import load_data
+
+
+def test_load_data_flag_conversion(tmp_path, monkeypatch):
+    # Create minimal CSV files expected by load_data
+    transactions = pd.DataFrame({
+        'sender_id': ['A'],
+        'receiver_id': ['B'],
+        'amount': [100],
+        'transaction_date': pd.to_datetime(['2021-01-01']),
+        'transaction_type': ['wire_transfer']
+    })
+    customers = pd.DataFrame({
+        'customer_id': ['B'],
+        'country': ['CountryA']
+    })
+    flagged = pd.DataFrame({
+        'transaction_date': pd.to_datetime(['2021-01-01']),
+        'sender_id': ['A'],
+        'receiver_id': ['B'],
+        'amount': [100],
+        'transaction_type': ['wire_transfer'],
+        'receiver_country': ['CountryA'],
+        'flags': ["['High-Value Transaction']"]
+    })
+
+    transactions.to_csv(tmp_path / 'synthetic_transactions.csv', index=False)
+    customers.to_csv(tmp_path / 'synthetic_customers.csv', index=False)
+    flagged.to_csv(tmp_path / 'flagged_transactions.csv', index=False)
+
+    monkeypatch.chdir(tmp_path)
+    t, c, f = load_data()
+
+    assert f['flags'].iloc[0] == ['High-Value Transaction']
+    exploded = f.explode('flags')
+    counts = exploded['flags'].value_counts().to_dict()
+    assert counts == {'High-Value Transaction': 1}


### PR DESCRIPTION
## Summary
- parse list-type flag columns with `ast.literal_eval`
- add regression test for `load_data`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683f4f780510833286e1fcd7b004b102